### PR TITLE
Add privacy policy page

### DIFF
--- a/privacy-policy.markdown
+++ b/privacy-policy.markdown
@@ -1,0 +1,9 @@
+---
+layout: page
+title: Privacy Policy
+permalink: /privacy-policy/
+---
+
+This personal blog exists to share my projects and thoughts. I do not run ads, track visitors, or collect personal data beyond standard hosting logs provided by GitHub Pages.
+
+If you reach out through the contact methods listed on this site, I will use your message solely to respond to you. You can email me anytime at [beria.giorgi1@gmail.com](mailto:beria.giorgi1@gmail.com).


### PR DESCRIPTION
## Summary
- add a dedicated privacy policy page clarifying the site is a personal blog and how to contact the owner

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d7a35c03108331bfcb4c1b0efbdd5c