### PR TITLE
Add post on n8n feature request workflow

### DIFF
--- a/_posts/2025-10-02-n8n-feature-request-system.markdown
+++ b/_posts/2025-10-02-n8n-feature-request-system.markdown
@@ -1,0 +1,46 @@
+---
+layout: post
+title: "Building a Customer-Centric Feature Request System with n8n"
+date: 2025-10-02 09:00:00 +0400
+categories: blog
+---
+
+Keeping product feedback organized is harder than collecting it. Ideas pour in from chats, meetings, and quick emails, then quietly disappear before anyone can size them up. I wanted a clearer way to respect every suggestion without adding more manual triage.
+
+![n8n feature request workflow diagram](/img/blog/n8n-feature-request-workflow.svg)
+
+### The Problem
+Feature requests often arrive through scattered channels, which means:
+
+- Ideas get lost in inboxes and threads.
+- Customers don’t get confirmation that their request was heard.
+- Teams waste time copying information into tracking tools.
+
+I needed something structured, transparent, and automated.
+
+### The Solution: an n8n-powered flow ⚙️
+n8n became the backbone of a lightweight workflow that connects customer submissions, my internal data table, and team communication.
+
+1. **Form submission** – Customers share their idea through a simple web form. Required fields (name, contact, feature description, priority 1–5) keep inputs consistent and reduce follow-up.
+2. **Insert into the data table** – Every submission lands in a data table with customer, contact, request details, priority, and a default status of “requested.” Sorting and prioritizing later becomes trivial.
+3. **Immediate confirmation** – n8n instantly replies with a friendly acknowledgement so customers know their idea is in the queue.
+4. **Real-time team notification** – A Discord message drops into the feature-request channel with the core details:
+   
+   ```text
+   📩 New Feature Request
+   👤 Name: <Customer>
+   📧 Contact: <Email/Phone>
+   💡 Request: <Feature description>
+   🔢 Priority: <1–5>
+   📌 Status: Requested
+   ⏰ Created At: <Timestamp>
+   ```
+
+### Why it matters
+This simple loop solves three persistent problems:
+
+- ✅ Feedback is never lost—everything lives in one source of truth.
+- ✅ Customers feel heard with immediate, personal confirmations.
+- ✅ Teams stay aligned because new requests are visible in real time without manual updates.
+
+By turning unstructured conversations into actionable records, the feature backlog stays honest, customers stay in the loop, and my team can focus on delivering the highest-impact ideas.

--- a/img/blog/n8n-feature-request-workflow.svg
+++ b/img/blog/n8n-feature-request-workflow.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 500">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#eef5ff" />
+      <stop offset="1" stop-color="#ffffff" />
+    </linearGradient>
+    <linearGradient id="node" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#5f8ef8" />
+      <stop offset="1" stop-color="#7fb6ff" />
+    </linearGradient>
+    <style>
+      text { font-family: 'Inter', 'Segoe UI', sans-serif; }
+      .title { font-size: 40px; font-weight: 600; fill: #1b3056; }
+      .subtitle { font-size: 20px; fill: #415a8b; }
+      .node-title { font-size: 22px; font-weight: 600; fill: #ffffff; }
+      .node-body { font-size: 18px; fill: #163158; }
+      .footer { font-size: 18px; fill: #617098; }
+    </style>
+  </defs>
+  <rect width="1200" height="500" fill="url(#bg)" rx="28" />
+  <text x="60" y="90" class="title">n8n Feature Request Workflow</text>
+  <text x="60" y="130" class="subtitle">Form submissions sync to a shared data table, confirm customers, and notify the team.</text>
+
+  <g transform="translate(80,180)">
+    <rect width="220" height="140" rx="22" fill="url(#node)" />
+    <text x="20" y="40" class="node-title">Form Submission</text>
+    <foreignObject x="20" y="55" width="180" height="80">
+      <body xmlns="http://www.w3.org/1999/xhtml">
+        <p style="margin:0;font:18px/24px 'Inter',sans-serif;color:#ebf2ff;">Structured input with name, contact, request &amp; priority.</p>
+      </body>
+    </foreignObject>
+  </g>
+
+  <g transform="translate(450,180)">
+    <rect width="240" height="140" rx="22" fill="#f7f9ff" stroke="#5f8ef8" stroke-width="4" />
+    <text x="20" y="40" class="node-body" style="font-weight:600;">Data Table Entry</text>
+    <foreignObject x="20" y="55" width="200" height="80">
+      <body xmlns="http://www.w3.org/1999/xhtml">
+        <p style="margin:0;font:18px/24px 'Inter',sans-serif;color:#274470;">Every request is logged with status, priority &amp; contact info.</p>
+      </body>
+    </foreignObject>
+  </g>
+
+  <g transform="translate(840,160)">
+    <rect width="260" height="180" rx="22" fill="#182b4d" />
+    <text x="30" y="50" class="node-title">Automation Outputs</text>
+    <foreignObject x="30" y="65" width="200" height="120">
+      <body xmlns="http://www.w3.org/1999/xhtml">
+        <ul style="margin:0;padding-left:16px;font:18px/26px 'Inter',sans-serif;color:#eef3ff;">
+          <li>Instant customer confirmation</li>
+          <li>Discord team alert</li>
+          <li>Timestamped status tracking</li>
+        </ul>
+      </body>
+    </foreignObject>
+  </g>
+
+  <path d="M300 250 H440" stroke="#5f8ef8" stroke-width="10" stroke-linecap="round" marker-end="url(#arrow)" fill="none" />
+  <path d="M690 250 H830" stroke="#5f8ef8" stroke-width="10" stroke-linecap="round" marker-end="url(#arrow)" fill="none" />
+
+  <defs>
+    <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L12,6 L0,12 z" fill="#5f8ef8" />
+    </marker>
+  </defs>
+
+  <text x="600" y="440" text-anchor="middle" class="footer">Automations keep customer requests organized, acknowledged, and visible to the whole team.</text>
+</svg>


### PR DESCRIPTION
## Summary
- add a new blog post about building a customer-centric feature request system with n8n
- include a supporting workflow illustration for the post

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdf9f37808331ba5ce2add3d6b9d2