### PR TITLE
Add MiniCrm launch announcement post

### DIFF
--- a/_posts/2025-10-17-minicrm-release.markdown
+++ b/_posts/2025-10-17-minicrm-release.markdown
@@ -1,0 +1,28 @@
+---
+layout: post
+title: "Shipping MiniCrm: A Lightweight Customer-Engagement Platform"
+date: 2025-10-17 09:00:00 +0400
+categories: blog
+---
+
+🚀 Excited to share MiniCrm!
+Over the past few sprints I've been building MiniCrm, a lightweight customer-engagement platform that punches far above its weight. It blends a polished React + Vite + PrimeReact front end with a rock-solid Django backend so growing teams can launch multi-channel campaigns—without enterprise overhead.
+
+Why I’m proud of this release
+✅ Unified outreach — Craft SMS and email campaigns in the same workspace, import contacts from Excel, and personalize messages on the fly with reusable templates.
+📊 Actionable analytics — Daily delivery trends, encoding breakdowns (GSM-7/Unicode), cost estimates, and template performance dashboards make it obvious where to double down.
+✍️ AI-assisted productivity — Built-in “Ask AI” helpers jumpstart copywriting, while bulk-send workflows keep teams focused on strategy, not busywork.
+🧾 Compliance-ready CRM — Consent tokens, detailed communication logs, and a data model keep operations audit-friendly.
+
+What’s new & noteworthy
+📝 Explicit consent collection — Capture and store permission for marketing emails/SMS (opt-in, double opt-in, and revocation), with time-stamped tokens and a full audit trail.
+🚀 Serious throughput — Thanks to background processing and queuing, MiniCrm can process ~50,000 SMS per hour, so you can scale peak campaigns.
+⚡ Fast & cost-effective SMS — Ships with a prebuilt integration to https://ubill.ge/ for quick setup and affordable delivery.
+
+Built for modern teams
+🛠️ Developer-friendly — React + Vite on the front, Django services on the back, with Dockerfiles for painless deployments.
+🧭 Operations-ready — Clear roles/permissions, environment-based configs, and observability hooks so you can ship safely and iterate quickly.
+
+If you’re scaling a customer success or growth team and tired of duct-taping point solutions, MiniCrm delivers clarity, automation, and control in one elegant package.
+Curious to see it in action? I can share a walkthrough or help you try it with your campaigns.
+#CustomerEngagement #GrowthMarketing #SaaS #ProductUpdate #MiniCrm #CRM #SMSMarketing #EmailMarketing #React #Vite #Django


### PR DESCRIPTION
## Summary
- add a new MiniCrm launch announcement blog post dated 2025-10-17
- describe product capabilities, throughput, and compliance updates with first-person framing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3448793a08331a48eb3e790f5cf62